### PR TITLE
[FEAT] Adding async to pangres :rocket: ??? 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           pytest -s -v pangres --cov=pangres --doctest-modules --sqlite_conn=sqlite:///:memory: --pg_conn=postgresql://circleci_user:password@localhost:5432/circleci_test?sslmode=disable --pg_conn_async=postgresql+asyncpg://circleci_user:password@localhost:5432/circleci_test --mysql_conn=mysql+pymysql://circleci_user:password@127.0.0.1:3306/circleci_test --mysql_conn_async=mysql+aiomysql://circleci_user:password@127.0.0.1:3306/circleci_test
           ## second test with sqlalchemy<1.4 (before API changes)
           pip install sqlalchemy==1.3.24
-          pytest -s -v pangres --cov=pangres --doctest-modules --sqlite_conn=sqlite:///:memory: --pg_conn=postgresql://circleci_user:password@localhost:5432/circleci_test?sslmode=disable --mysql_conn=mysql+pymysql://circleci_user:password@127.0.0.1:3306/circleci_test
+          pytest -s -v pangres --cov=pangres --cov-append --doctest-modules --sqlite_conn=sqlite:///:memory: --pg_conn=postgresql://circleci_user:password@localhost:5432/circleci_test?sslmode=disable --mysql_conn=mysql+pymysql://circleci_user:password@127.0.0.1:3306/circleci_test
           codecov
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,11 +40,12 @@ jobs:
           # install package (fetches setup.py in current directory)
           pip install .
           # we need cryptography for MySQL
-          pip install codecov coverage numpy pytest pytest-benchmark pytest-cov
-          pip install psycopg2 pymysql cryptography tabulate npdoc_to_md
+          pip install codecov coverage numpy pytest pytest-benchmark pytest-cov pytest-asyncio
+          pip install psycopg2 pymysql asyncpg aiomysql cryptography tabulate npdoc_to_md
           # use pytest
           ## first test with sqlalchemy latest i.e. sqlalchemy>=1.4 (after API changes, notably engine.has_table being deprecated)
-          pytest -s -v pangres --cov=pangres --doctest-modules --sqlite_conn=sqlite:///:memory: --pg_conn=postgresql://circleci_user:password@localhost:5432/circleci_test?sslmode=disable --mysql_conn=mysql+pymysql://circleci_user:password@127.0.0.1:3306/circleci_test
+          ## also, we can only test async engines with sqlalchemy>=1.4
+          pytest -s -v pangres --cov=pangres --doctest-modules --sqlite_conn=sqlite:///:memory: --pg_conn=postgresql://circleci_user:password@localhost:5432/circleci_test?sslmode=disable --pg_conn_async=postgresql+asyncpg://circleci_user:password@localhost:5432/circleci_test?sslmode=disable --mysql_conn=mysql+pymysql://circleci_user:password@127.0.0.1:3306/circleci_test --mysql_conn_async=mysql+aiomysql://circleci_user:password@127.0.0.1:3306/circleci_test
           ## second test with sqlalchemy<1.4 (before API changes)
           pip install sqlalchemy==1.3.24
           pytest -s -v pangres --cov=pangres --doctest-modules --sqlite_conn=sqlite:///:memory: --pg_conn=postgresql://circleci_user:password@localhost:5432/circleci_test?sslmode=disable --mysql_conn=mysql+pymysql://circleci_user:password@127.0.0.1:3306/circleci_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           # use pytest
           ## first test with sqlalchemy latest i.e. sqlalchemy>=1.4 (after API changes, notably engine.has_table being deprecated)
           ## also, we can only test async engines with sqlalchemy>=1.4
-          pytest -s -v pangres --cov=pangres --doctest-modules --sqlite_conn=sqlite:///:memory: --pg_conn=postgresql://circleci_user:password@localhost:5432/circleci_test?sslmode=disable --pg_conn_async=postgresql+asyncpg://circleci_user:password@localhost:5432/circleci_test?sslmode=disable --mysql_conn=mysql+pymysql://circleci_user:password@127.0.0.1:3306/circleci_test --mysql_conn_async=mysql+aiomysql://circleci_user:password@127.0.0.1:3306/circleci_test
+          pytest -s -v pangres --cov=pangres --doctest-modules --sqlite_conn=sqlite:///:memory: --pg_conn=postgresql://circleci_user:password@localhost:5432/circleci_test?sslmode=disable --pg_conn_async=postgresql+asyncpg://circleci_user:password@localhost:5432/circleci_test --mysql_conn=mysql+pymysql://circleci_user:password@127.0.0.1:3306/circleci_test --mysql_conn_async=mysql+aiomysql://circleci_user:password@127.0.0.1:3306/circleci_test
           ## second test with sqlalchemy<1.4 (before API changes)
           pip install sqlalchemy==1.3.24
           pytest -s -v pangres --cov=pangres --doctest-modules --sqlite_conn=sqlite:///:memory: --pg_conn=postgresql://circleci_user:password@localhost:5432/circleci_test?sslmode=disable --mysql_conn=mysql+pymysql://circleci_user:password@127.0.0.1:3306/circleci_test

--- a/README.md
+++ b/README.md
@@ -88,10 +88,12 @@ If you wish you can also use the provided environment (see `environment.yml` fil
 You can test one or multiple of the following SQL flavors (you will of course need a live database for this): PostgreSQL, SQlite or MySQL.
 
 Clone pangres then set your curent working directory to the root of the cloned repository folder. Then use the commands below. You will have to replace the following variables in those commands:
-* SQLITE_CONNECTION_STRING: replace with a SQlite sqlalchemy connection string (e.g. "sqlite:///test.db")
-* POSTGRES_CONNECTION_STRING: replace with a Postgres sqlalchemy connection string (e.g. "postgres:///user:password@localhost:5432/database"). Specifying schema is optional for postgres (will default to public).
+* SQLITE_CONN: replace with a SQlite sqlalchemy connection string (e.g. "sqlite:///test.db")
+* PG_CONN: replace with a Postgres sqlalchemy connection string (e.g. "postgres:///user:password@localhost:5432/database")
+* PG_CONN_ASYNC: replace with an asynchronous Postgres sqlalchemy connection string (e.g. "postgres+asyncpg:///user:password@localhost:5432/database")
+* MYSQL_CONN: replace with a MySQL sqlalchemy connection string (e.g. "mysql+pymysql:///user:password@localhost:3306/database")
+* MYSQL_CONN_ASYNC: replace with an asynchronous MySQL sqlalchemy connection string (e.g. "mysql+aiomysql:///user:password@localhost:3306/database")
 * PG_SCHEMA (optional): schema for postgres (defaults to public)
-* MYSQL_CONNECTION_STRING: replace with a MySQL sqlalchemy connection string (e.g. "mysql+pymysql:///user:password@localhost:3306/database")
 
 ```shell
 # 1. Create and activate the build environment
@@ -104,5 +106,5 @@ pip install -e .
 # -v prints test parameters
 # --cov=./pangres shows coverage only for pangres
 # --doctest-modules tests with doctest in all modules
-pytest -s -v pangres --cov=pangres --doctest-modules --sqlite_conn=$SQLITE_CONNECTION_STRING --pg_conn=$POSTGRES_CONNECTION_STRING --mysql_conn=$MYSQL_CONNECTION_STRING --pg_schema=tests
+pytest -s -v pangres --cov=pangres --doctest-modules --sqlite_conn=$SQLITE_CONNECTION_STRING --pg_conn=$PG_CONN --pg_conn_async=$PG_CONN_ASYNC --mysql_conn=$MYSQL_CONN --mysql_conn_async=$MYSQL_CONN_ASYNC --pg_schema=tests
 ```

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,5 +18,5 @@ coverage:
         base: auto
 
 ignore:
-  - "pangres/docs/*"  # ignore script to generate the documentation
-  - "pangres/pangres/tests/*"
+  - "**/docs/*"  # ignore script to generate the documentation
+  - "**/tests/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,4 +19,4 @@ coverage:
 
 ignore:
   - "pangres/docs/*"  # ignore script to generate the documentation
-  - "pangres/pangres/tests/test_upsert_speed.py" # the pytest benchmarking extension has problems with coverage
+  - "pangres/pangres/tests/*"

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-benchmark
+  - pytest-asyncio
   - psycopg2
   - pymysql
   - tabulate

--- a/pangres/__init__.py
+++ b/pangres/__init__.py
@@ -1,4 +1,4 @@
-from pangres.core import upsert
+from pangres.core import upsert, aupsert
 from pangres.utils import fix_psycopg2_bad_cols
 from pangres.examples import DocsExampleTable
 from pangres._version import __version__

--- a/pangres/core.py
+++ b/pangres/core.py
@@ -253,7 +253,8 @@ def upsert(engine,
 # # async upsert
 
 async def aupsert(engine, df, table_name, if_row_exists, schema=None, create_schema=False,
-                 create_table=True, chunksize=10000, dtype=None):
+                  create_table=True, chunksize=10000, dtype=None,
+                  handle_concurrent_objects_creation=True):
     """
     Async variant of `pangres.upsert`. The engine must use an asynchronous driver
     such as `asyncpg` for PostgreSQL, or `aiomysql` for MySQL etc.
@@ -277,9 +278,21 @@ async def aupsert(engine, df, table_name, if_row_exists, schema=None, create_sch
     >
     > Source: https://docs.sqlalchemy.org/en/14/orm/extensions/asyncio.html (2021-11-03)
 
-    See docstring of `pangres.upsert` for details on the parameters.
+    See docstring of `pangres.upsert` for details on the parameters that are not described below.
     Some parameters are missing in this asynchronous variant of `pangres.uspert` because
     of a lack of time/knowledge. I'd be glad if you are willing to help.
+
+    Parameters
+    ----------
+    handle_concurrent_objects_creation : bool, default True
+        Only relevant when `create_schema` or `create_table` are set to True.
+        If True, handles the case when multiple connections try to create the same
+        object (given table or schema) at the same time.
+        This can happen for instance if you execute in parallel multiple `aupsert`
+        coroutines for a same table which does not exist yet.
+        In such a case it is possible that the SQL server tells more than one coroutine
+        that the table does not exist yet. We would then have multiple create statements
+        issued at the same time for the same table which would throw an error.
 
     Notes
     -----

--- a/pangres/core.py
+++ b/pangres/core.py
@@ -259,8 +259,23 @@ async def aupsert(engine, df, table_name, if_row_exists, schema=None, create_sch
     such as `asyncpg` for PostgreSQL, or `aiomysql` for MySQL etc.
     You will need to install this driver e.g. `pip install asyncpg`.
 
-    Support for different drivers may vary depending on the SQLalchemy version.
-    In any case, version 1.4. is the minimum requirement.
+    Such asynchronous engines are only available from version 1.4. onwards.
+    Not all databases/drivers are supported by `sqlalchemy` yet.
+    E.g. `aiosqlite` does not seem to work in version 1.4.x.
+
+    WARNING:
+    This is an experimental feature. Usage may change without warnings in the next
+    versions of pangres and compatibility with sqlalchemy versions different than
+    1.4. is not guaranteed.
+    While this function has been well tested in `pangres` there could still be changes
+    when it comes to asynchronous engines in `sqlalchemy`:
+
+    > The asyncio extension as of SQLAlchemy 1.4.3 can now be considered to be
+    > beta level software.
+    > API details are subject to change however at this point it is unlikely for
+    > there to be significant backwards-incompatible changes.
+    >
+    > Source: https://docs.sqlalchemy.org/en/14/orm/extensions/asyncio.html (2021-11-03)
 
     See docstring of `pangres.upsert` for details on the parameters.
     Some parameters are missing in this asynchronous variant of `pangres.uspert` because

--- a/pangres/core.py
+++ b/pangres/core.py
@@ -253,7 +253,7 @@ def upsert(engine,
 # # async upsert
 
 async def aupsert(engine, df, table_name, if_row_exists, schema=None, create_schema=False,
-                 create_table=True, chunksize=10000, dtype=None, yield_chunks=False):
+                 create_table=True, chunksize=10000, dtype=None):
     """
     Async variant of `pangres.upsert`. The engine must use an asynchronous driver
     such as `asyncpg` for PostgreSQL, or `aiomysql` for MySQL etc.
@@ -319,5 +319,4 @@ async def aupsert(engine, df, table_name, if_row_exists, schema=None, create_sch
     if len(df) == 0:
         return
 
-    # returns an iterator when we yield chunks otherwise None
-    return await pse.aupsert(if_row_exists=if_row_exists, chunksize=chunksize, yield_chunks=yield_chunks)
+    return await pse.aupsert(if_row_exists=if_row_exists, chunksize=chunksize)

--- a/pangres/core.py
+++ b/pangres/core.py
@@ -338,9 +338,9 @@ async def aupsert(engine, df, table_name, if_row_exists, schema=None, create_sch
 
     # create schema and table if not exists then insert values
     if create_schema and schema is not None:
-        await pse.acreate_schema_if_not_exists()
+        await pse.acreate_schema_if_not_exists(handle_concurrent_objects_creation=handle_concurrent_objects_creation)
     if create_table:
-        await pse.acreate_table_if_not_exists()
+        await pse.acreate_table_if_not_exists(handle_concurrent_objects_creation=handle_concurrent_objects_creation)
 
     # stop if no rows
     ## note: use simple check with len() as df.empty returns True if there are index values but no columns

--- a/pangres/helpers.py
+++ b/pangres/helpers.py
@@ -575,8 +575,9 @@ class PandasSpecialEngine:
             f = lambda connection: self.table.create(bind=connection, checkfirst=True)
             await connection.run_sync(f)
             await connection.commit()
-    
-    async def aupsert(self, if_row_exists, chunksize=10000, yield_chunks=False):
+
+
+    async def aupsert(self, if_row_exists, chunksize=10000):
         if if_row_exists not in ('ignore', 'update'):
             raise ValueError('if_row_exists must be "ignore" or "update"')
         # convert values if needed
@@ -586,16 +587,12 @@ class PandasSpecialEngine:
         # create chunks
         chunks = self._create_chunks(values=values, chunksize=chunksize)
         upq = UpsertQuery(engine=self.engine, table=self.table)
+        # I tried the same strategy as in upsert for yielding chunks
+        # by using a "subcoroutine" which returns a generator
+        # (... yield await chunk) but that does not work
+        for chunk in chunks:
+            await upq.aexecute(db_type=self._db_type, values=chunk, if_row_exists=if_row_exists)
 
-        # see comment in sync variant
-        if not yield_chunks:
-            for chunk in chunks:
-                await upq.aexecute(db_type=self._db_type, values=chunk, if_row_exists=if_row_exists)
-        else:
-            async def yield_chunks_func():
-                for chunk in chunks:
-                    yield await upq.aexecute(db_type=self._db_type, values=chunk, if_row_exists=if_row_exists)
-            return yield_chunks_func()
 
     def __repr__(self):
         text = f"""PandasSpecialEngine (id {id(self)}, hexid {hex(id(self))})

--- a/pangres/tests/conftest.py
+++ b/pangres/tests/conftest.py
@@ -5,6 +5,7 @@
 Configuration and helpers for the tests of pangres with pytest.
 """
 import pandas as pd
+import pytest
 import json
 from sqlalchemy import create_engine, MetaData, Table, text
 from sqlalchemy import inspect as sqla_inspect
@@ -15,6 +16,40 @@ from pangres.helpers import _sqla_gt14
 # -
 
 # # Helpers
+
+# ## ConnectionString object
+
+class ConnectionString:
+    def __init__(self, string, is_async=False, schema=None):
+        self._string = string
+        self._is_async = is_async
+        self._schema = schema
+
+    @property
+    def string(self):
+        return self._string
+
+    @property
+    def is_async(self):
+        return self._is_async
+
+    @property
+    def schema(self):
+        return self._schema
+
+
+    def get_engine(self, **kwargs):
+        if not self._is_async:
+            return create_engine(self._string, **kwargs)
+        else:
+            if not _sqla_gt14():
+                from sqlalchemy import __version__ as sqla_version
+                raise NotImplementedError('Async engines require sqlalchemy >= 1.4. '
+                                          f'Current version is {sqla_version}')
+            else:
+                from sqlalchemy.ext.asyncio import create_async_engine
+                return create_async_engine(self._string, **kwargs)
+
 
 # ## Functions for dropping a table
 
@@ -66,37 +101,70 @@ async def adrop_table_if_exists(engine, schema, table_name):
         await connection.run_sync(_drop_table_from_conn, schema=schema, table_name=table_name)
         await connection.commit()
 
+
+# -
+
+# # Pytest functions
+
 # +
 def pytest_addoption(parser):
     parser.addoption('--sqlite_conn', action="store", default=None)
     parser.addoption('--pg_conn', action="store", default=None)
     parser.addoption('--mysql_conn', action="store", default=None)
+    parser.addoption('--pg_conn_async', action="store", default=None)
+    parser.addoption('--mysql_conn_async', action="store", default=None)
     parser.addoption('--pg_schema', action='store', default=None)
 
+# this is called for every test
 def pytest_generate_tests(metafunc):
-    # This is called for every test. Only get/set command line arguments
-    # if the argument is specified in the list of test "fixturenames".
-    conn_strings = {'sqlite':metafunc.config.option.sqlite_conn,
-                    'pg':metafunc.config.option.pg_conn,
-                    'mysql':metafunc.config.option.mysql_conn}
-    engines = []
-    schemas = []
-    for db_type, conn_string in conn_strings.items():
-        if conn_string is None:
-            continue
-        schema = metafunc.config.option.pg_schema if db_type == 'pg' else None
-        engine = create_engine(conn_string)
-        schemas.append(schema)
-        engines.append(engine)
-        # for sqlalchemy 1.4+ use future=True to try the future sqlalchemy 2.0
-        if _sqla_gt14():
-            future_engine = create_engine(conn_string, future=True)
-            schemas.append(schema)
-            engines.append(future_engine)
-    assert len(engines) == len(schemas)
-    if len(engines) == 0:
+    options = metafunc.config.option
+    pg_schema = options.pg_schema if options.pg_schema is not None else 'public'
+    conn_strings = [ConnectionString(string=options.sqlite_conn),
+                    ConnectionString(string=options.pg_conn, schema=pg_schema),
+                    ConnectionString(string=options.mysql_conn),
+                    ConnectionString(string=options.pg_conn_async, is_async=True, schema=pg_schema),
+                    ConnectionString(string=options.mysql_conn_async, is_async=True)]
+
+    # filter connection strings (not provided ones will be None)
+    conn_strings = [c for c in conn_strings if c.string is not None]
+    if len(conn_strings) == 0:
         raise ValueError('You must provide at least one connection string (e.g. argument --sqlite_conn)!')
-    metafunc.parametrize("engine, schema", list(zip(engines, schemas)), scope='module')
+
+    # prepare parameters for tests
+    engines, schemas, ids = [], [], []
+    is_async_test_module = metafunc.module.__name__.endswith('_async')
+    for conn_string in conn_strings:
+        # skip sync tests for async engines
+        if conn_string.is_async and not is_async_test_module:
+            continue
+        # skip async tests for sync engines
+        if not conn_string.is_async and is_async_test_module:
+            continue
+
+        # get engine and schemas that we will use as parameters for all tests
+        engine, schema = conn_string.get_engine(), conn_string.schema
+        engines.append(engine)
+        schemas.append(schema)
+        ids.append(f'{engine.url.drivername}_{schema}')
+
+        # for sqlalchemy 1.4+ use future=True to try the future sqlalchemy 2.0
+        # (only for non async engines)
+        if _sqla_gt14() and not conn_string.is_async:
+            future_engine = conn_string.get_engine(future=True)
+            engines.append(future_engine)
+            schemas.append(schema)
+            ids.append(f'{future_engine.url.drivername}_FUTURE_{schema}')
+
+    # verifications
+    assert len(engines) == len(schemas) == len(ids)
+
+    # handle case when there is nothing to test
+    if len(engines) == 0:
+        pytest.skip()
+
+    # generate tests
+    params = list(zip(engines, schemas))
+    metafunc.parametrize("engine, schema", params, ids=ids, scope='module')
 
 
 # -

--- a/pangres/tests/conftest.py
+++ b/pangres/tests/conftest.py
@@ -169,22 +169,39 @@ def pytest_generate_tests(metafunc):
 
 # -
 
-# ## Function to read back from database data we inserted
-# We need to apply a few modification for comparing DataFrames we get back from the DB and DataFrames we expect e.g. for JSON (with SQlite pandas reads it as string).
+# ## Tool for reading example data we inserted in the database
 
-def read_example_table_from_db(engine, schema, table_name):
-    def load_json_if_needed(obj):
-        """
-        For SQlite we receive strings back (or None) for a JSON column.
-        For Postgres we receive lists or dicts (or None) back.
-        """
-        if isinstance(obj, str):
-            return json.loads(obj)
-        return obj
-    namespace = f'{schema}.{table_name}' if schema is not None else table_name
-    with engine.connect() as connection:
-        df_db = (pd.read_sql(text(f'SELECT * FROM {namespace}'), con=connection, index_col='profileid')
-                 .astype({'likes_pizza':bool})
-                 .assign(timestamp=lambda df: pd.to_datetime(df['timestamp'], utc=True))
-                 .assign(favorite_colors= lambda df: df['favorite_colors'].map(load_json_if_needed)))
-    return df_db
+class ReaderSQLExampleTables:
+    """
+    Tool for reading and then wrangling example tables we saved in SQL
+    databases for our tests.
+    This is necessary because we can get different data
+    back than what we would expect e.g. for JSON in SQlite,
+    pandas will read it as a string.
+    After we have applied this sort of normalization
+    we can compare DataFrames in memory with tables
+    in SQL databases.
+    """
+    def _wrangle(df):
+        json_convert = lambda obj: json.loads(obj) if isinstance(obj, str) else obj
+        return (df.astype({'likes_pizza':bool})
+                .assign(timestamp=lambda df: pd.to_datetime(df['timestamp'], utc=True))
+                .assign(favorite_colors=lambda df: df['favorite_colors'].map(json_convert)))
+
+
+    def read(engine, schema, table_name):
+        namespace = f'{schema}.{table_name}' if schema is not None else table_name
+        with engine.connect() as connection:
+            df_db = pd.read_sql(text(f'SELECT * FROM {namespace}'), con=connection, index_col='profileid')
+            return ReaderSQLExampleTables._wrangle(df_db)
+
+
+    # async variant
+    async def aread(engine, schema, table_name):
+        namespace = f'{schema}.{table_name}' if schema is not None else table_name
+        async with engine.connect() as connection:
+            # pandas does not support async engines yet
+            proxy = await connection.execute(text(f'SELECT * FROM {namespace}'))
+            results = [r._asdict() for r in proxy.all()]
+            df_db = pd.DataFrame(results).set_index('profileid')
+            return ReaderSQLExampleTables._wrangle(df_db)

--- a/pangres/tests/test_async.py
+++ b/pangres/tests/test_async.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""
+Async specific tests
+"""
+import asyncio
+import math
+import pandas as pd
+import pytest
+from sqlalchemy import VARCHAR
+from pangres import aupsert
+from pangres.examples import _TestsExampleTable
+from pangres.tests.conftest import ReaderSQLExampleTables, adrop_table_if_exists
+
+# # Check if we can run two parallel upsert commands at once even though they try to create a table
+
+def test_no_conflict_table_creation(engine, schema):
+    table_name = 'test_async_no_conflict_table_creation'
+
+    # drop table if exists
+    loop = asyncio.get_event_loop()
+    coroutines = [adrop_table_if_exists(engine=engine, schema=schema, table_name=table_name)]
+    tasks = asyncio.gather(*coroutines)
+    loop.run_until_complete(tasks)
+
+    # the 2 coroutines below are both going to try to create the table.
+    # As the table does not exist yet we check if there is any
+    # race condition problem here
+    df = pd.DataFrame({'id':[1], 'value':[100]}).set_index('id')
+    kwargs = dict(engine=engine, schema=schema, table_name=table_name,
+                  df=df, create_table=True, if_row_exists='update')
+    coroutines = [aupsert(**kwargs), aupsert(**kwargs)]
+    tasks = asyncio.gather(*coroutines, return_exceptions=True)
+    results = loop.run_until_complete(tasks)
+    for r in results:
+        if isinstance(r, Exception):
+            raise r

--- a/pangres/tests/test_chunsize.py
+++ b/pangres/tests/test_chunsize.py
@@ -8,7 +8,7 @@ import pandas as pd
 from sqlalchemy import VARCHAR
 from pangres import upsert
 from pangres.examples import _TestsExampleTable
-from pangres.tests.conftest import read_example_table_from_db, drop_table_if_exists
+from pangres.tests.conftest import ReaderSQLExampleTables, drop_table_if_exists
 
 
 # # Helpers
@@ -25,7 +25,7 @@ def insert_chunks(engine, schema, chunksize, nb_rows):
            if_row_exists='update',
            # MySQL does not want flexible text length in indices/PK
            dtype={'profileid':VARCHAR(10)} if 'mysql' in engine.dialect.dialect_description else None)
-    df_db = read_example_table_from_db(engine=engine, schema=schema, table_name=table_name)
+    df_db = ReaderSQLExampleTables.read(engine=engine, schema=schema, table_name=table_name)
     # sort index (for MySQL...)
     pd.testing.assert_frame_equal(df.sort_index(), df_db.sort_index())
 

--- a/pangres/tests/test_chunsize_async.py
+++ b/pangres/tests/test_chunsize_async.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""
+Async variant of module test_chunksize. See its docstring.
+"""
+import pandas as pd
+import pytest
+from sqlalchemy import VARCHAR
+from pangres import aupsert
+from pangres.examples import _TestsExampleTable
+from pangres.tests.conftest import ReaderSQLExampleTables, adrop_table_if_exists
+
+# # Helpers
+
+async def insert_chunks(engine, schema, chunksize, nb_rows):
+    df = _TestsExampleTable.create_example_df(nb_rows=nb_rows)
+    table_name=f'test_insert_chunksize_{chunksize}'
+    await adrop_table_if_exists(engine=engine, schema=schema, table_name=table_name)
+    await aupsert(schema=schema,
+                  table_name=table_name,
+                  df=df,
+                  chunksize=chunksize,
+                  engine=engine,
+                  if_row_exists='update',
+                  # MySQL does not want flexible text length in indices/PK
+                  dtype={'profileid':VARCHAR(10)} if 'mysql' in engine.dialect.dialect_description else None)
+    df_db = await ReaderSQLExampleTables.aread(engine=engine, schema=schema, table_name=table_name)
+    # sort index (for MySQL...)
+    pd.testing.assert_frame_equal(df.sort_index(), df_db.sort_index())
+
+# # Tests
+
+# ## Insert values one by one
+
+@pytest.mark.asyncio
+async def test_insert_one(engine, schema):
+    await insert_chunks(engine, schema, chunksize=1, nb_rows=11)
+
+# ## Insert an odd size of chunks that is not a multiple of df length
+
+@pytest.mark.asyncio
+async def test_insert_odd_chunksize(engine, schema):
+    await insert_chunks(engine, schema, chunksize=3, nb_rows=11)
+

--- a/pangres/tests/test_index_async.py
+++ b/pangres/tests/test_index_async.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""
+Async variant of module test_index. See its docstring.
+"""
+import pandas as pd
+import pytest
+from sqlalchemy import VARCHAR, text
+from sqlalchemy.exc import IntegrityError
+from pangres import aupsert
+from pangres.tests.conftest import adrop_table_if_exists
+
+
+# # Config
+
+# +
+# for creating table with MultiIndex
+index_col = ['ix1', 'ix2', 'ix3']
+df_multiindex = pd.DataFrame({'ix1': [1, 1], 'ix2': ['test', 'test2'], 
+                              'ix3': [pd.Timestamp('2019-01-01'), pd.Timestamp('2019-01-02')],
+                              'foo': [1, 2]}).set_index(index_col)
+
+# for inserting values
+df_multiindex2 = pd.DataFrame({'ix1': [2, 2], 'ix2': ['test', 'test2'], 
+                              'ix3': [pd.Timestamp('2019-01-01'), pd.Timestamp('2019-01-02')],
+                              'foo': [1, 2]}).set_index(index_col)
+
+default_args = {'if_row_exists':'update'}
+# -
+
+# # Tests
+
+# ## Test MultiIndex
+
+@pytest.mark.asyncio
+async def test_create_and_insert_table_multiindex(engine, schema):
+    table_name = 'test_multiindex'
+    namespace = f'{schema}.{table_name}' if schema is not None else table_name
+    await adrop_table_if_exists(engine=engine, schema=schema, table_name=table_name)
+    # dtype for index for MySQL... (can't have flexible text length)
+    dtype = {'ix2':VARCHAR(5)} if 'mysql' in engine.dialect.dialect_description else None
+
+    # local helper
+    async def read_from_db():
+        async with engine.connect() as connection:
+            proxy = await connection.execute(text(f'SELECT * FROM {namespace}'))
+            results = [r._asdict() for r in proxy.all()]
+            return pd.DataFrame(results).set_index(index_col)
+
+    # create
+    await aupsert(engine=engine, schema=schema, df=df_multiindex, table_name=table_name, dtype=dtype, **default_args)
+    db_db = await read_from_db()
+
+    # insert
+    await aupsert(engine=engine, schema=schema, df=df_multiindex2, table_name=table_name, dtype=dtype, **default_args)
+    db_db = await read_from_db()
+
+# ## Test index with null value
+
+@pytest.mark.asyncio
+async def test_index_with_null(engine, schema):
+    df = pd.DataFrame({'ix':[None], 'foo': [2]}).set_index('ix')
+    table_name='test_index_with_null'
+    await adrop_table_if_exists(engine=engine, schema=schema, table_name=table_name)
+    # don't test for mysql since only a warning is raised and the line is skipped
+    if not 'mysql' in engine.dialect.dialect_description:
+        try:
+            await aupsert(engine=engine, schema=schema, df=df, table_name=table_name, **default_args)
+            raise ValueError('upsert did not fail as expected with null value in index')
+        except IntegrityError as e:
+            print(f'upsert failed as expected with null value in index. Error was:\n\n{e}')
+
+# ## Test only index
+
+# +
+# using pytest.mark.asyncio is mandatory
+# and combined with pytest parametrize this makes coroutines
+# with different parameters execute in parallel
+# this is problematic because we are dropping tables
+# so we need to make multiple test functions instead
+async def execute_test_only_index(engine, schema, if_row_exists):
+    # upsert df with only index
+    df = pd.DataFrame({'ix':[1]}).set_index('ix')
+    table_name='test_index_only'
+    await adrop_table_if_exists(engine=engine, schema=schema, table_name=table_name)
+    await aupsert(engine=engine, schema=schema, df=df, table_name=table_name, if_row_exists=if_row_exists)
+
+    # check data integrity
+    namespace = f'{schema}.{table_name}' if schema is not None else table_name
+    async with engine.connect() as connection:
+        proxy = await connection.execute(text(f'SELECT * FROM {namespace}'))
+        results = [r._asdict() for r in proxy.all()]
+        df_db = pd.DataFrame(results)
+
+    assert 'ix' in df_db.columns
+    assert len(df_db) > 0
+    assert df_db['ix'].iloc[0] == 1
+
+@pytest.mark.asyncio
+async def test_only_index_on_conflict_ignore(engine, schema):
+    await execute_test_only_index(engine=engine, schema=schema, if_row_exists='ignore')
+
+@pytest.mark.asyncio
+async def test_only_index_on_conflict_update(engine, schema):
+    await execute_test_only_index(engine=engine, schema=schema, if_row_exists='update')

--- a/pangres/tests/test_unique_key_async.py
+++ b/pangres/tests/test_unique_key_async.py
@@ -1,0 +1,90 @@
+"""
+Async variant of module test_unique_key. See its docstring.
+"""
+import pandas as pd
+import datetime
+import pytest
+from pangres import aupsert
+from pangres.tests.conftest import adrop_table_if_exists
+from sqlalchemy import INTEGER, VARCHAR, MetaData, Column, text, UniqueConstraint
+from sqlalchemy.ext.declarative import declarative_base
+
+# # Helpers
+
+# ## Table model
+
+# +
+table_name = 'test_unique_key'
+
+async def create_test_table(engine, schema):
+    Base = declarative_base(bind=engine)
+
+    class TestUniqueKey(Base):
+        __tablename__ = table_name
+        __table_args__ = (UniqueConstraint('order_id', 'product_id'),
+                          {'schema':schema})
+
+        row_id = Column(INTEGER, primary_key=True, autoincrement=True)
+        order_id = Column(VARCHAR(5), nullable=False, server_default='-9999')
+        product_id = Column(VARCHAR(5), nullable=False, server_default='-9999')
+        qty = Column(INTEGER, nullable=True, comment='purchase_quantity')
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+# -
+
+# ## Data to be inserted/upserted in tests
+
+# +
+# initial data (first upsert)
+data_old = {'order_id': ['A0001', 'A0002', 'A0002'],
+            'product_id': ['PD100', 'PD200', 'PD201'],
+            'qty': [10, 20, 22]}
+df_old = pd.DataFrame(data_old).set_index(['order_id', 'product_id'])
+
+# new data (second upsert)
+data_new = {'order_id': ['A0001', 'A0002', 'A0002', 'A0003'],
+            'product_id': ['PD100', 'PD200', 'PD201', 'PD300'],
+            'qty': [10, 20, 77, 30]}
+df_new = pd.DataFrame(data_new).set_index(['order_id', 'product_id'])
+# -
+
+# # Unique key test
+
+@pytest.mark.asyncio
+async def test_upsert_with_unique_keys(engine, schema):
+
+    # helpers
+    namespace = f'{schema}.{table_name}' if schema is not None else table_name
+    # local helper
+    async def read_from_db():
+        async with engine.connect() as connection:
+            proxy = await connection.execute(text(f'SELECT * FROM {namespace}'))
+            results = [r._asdict() for r in proxy.all()]
+            return pd.DataFrame(results).set_index('row_id')
+
+    # create our test table
+    await adrop_table_if_exists(engine=engine, schema=schema, table_name=table_name)
+    await create_test_table(engine=engine, schema=schema)
+
+    # add initial data (df_old)
+    await aupsert(engine=engine, df=df_old, schema=schema, table_name='test_unique_key', if_row_exists='update')
+    df = await read_from_db()
+    df_expected = df_old.assign(row_id=range(1, 4)).reset_index().set_index('row_id')
+    pd.testing.assert_frame_equal(df, df_expected)
+
+    # add new data (df_new)
+    await aupsert(engine=engine, df=df_new, schema=schema, table_name='test_unique_key', if_row_exists='update')
+    df = await read_from_db()
+    # before creating our expected df we need to implement the special case of postgres
+    # where the id of the last row will be 7 instead of 4. I suppose that PG's ON
+    # CONFLICT UPDATE clause will run in such a way that it will count 4 (number we
+    # would expected) + 3 (three previous rows that were updated)
+    last_row_id = 7 if 'postgres' in engine.dialect.dialect_description else 4
+    df_expected = (pd.DataFrame([[1, 'A0001', 'PD100', 10],
+                                 [2, 'A0002', 'PD200', 20],
+                                 [3, 'A0002', 'PD201', 77],
+                                 [last_row_id, 'A0003', 'PD300', 30]],
+                                columns=['row_id'] + df_old.reset_index().columns.tolist())
+                   .set_index('row_id'))
+    pd.testing.assert_frame_equal(df, df_expected)

--- a/pangres/tests/test_upsert.py
+++ b/pangres/tests/test_upsert.py
@@ -11,7 +11,7 @@ import random
 from sqlalchemy import VARCHAR
 from pangres import upsert, fix_psycopg2_bad_cols
 from pangres.examples import _TestsExampleTable
-from pangres.tests.conftest import read_example_table_from_db, drop_table_if_exists
+from pangres.tests.conftest import ReaderSQLExampleTables, drop_table_if_exists
 
 
 # # Config
@@ -50,7 +50,7 @@ def test_create_table(engine, schema):
     
     drop_table_if_exists(engine=engine, schema=schema, table_name=table_name)
     upsert(engine=engine, schema=schema, df=df, if_row_exists='update', dtype=dtype, **default_args)
-    df_db = read_example_table_from_db(engine=engine, schema=schema, table_name=table_name)
+    df_db = ReaderSQLExampleTables.read(engine=engine, schema=schema, table_name=table_name)
     pd.testing.assert_frame_equal(df, df_db)
 
 
@@ -60,7 +60,7 @@ def test_upsert_update(engine, schema):
     dtype = {'profileid':VARCHAR(10)} if 'mysql' in engine.dialect.dialect_description else None
 
     upsert(engine=engine, schema=schema, df=df2, if_row_exists='update', dtype=dtype, **default_args)
-    df_db = read_example_table_from_db(engine=engine, schema=schema, table_name=table_name)
+    df_db = ReaderSQLExampleTables.read(engine=engine, schema=schema, table_name=table_name)
     pd.testing.assert_frame_equal(df2, df_db)
 
 
@@ -68,11 +68,11 @@ def test_upsert_update(engine, schema):
 
 def test_upsert_ignore(engine, schema):
     dtype = {'profileid':VARCHAR(10)} if 'mysql' in engine.dialect.dialect_description else None
-    
+
     drop_table_if_exists(engine=engine, schema=schema, table_name=table_name)
     for _df in (df, df3):
         upsert(engine=engine, schema=schema, df=_df, if_row_exists='ignore', dtype=dtype, **default_args)
-    df_db = read_example_table_from_db(engine=engine, schema=schema, table_name=table_name)
+    df_db = ReaderSQLExampleTables.read(engine=engine, schema=schema, table_name=table_name)
     expected = pd.concat((df, df3.tail(1)), axis=0)
     pd.testing.assert_frame_equal(expected, df_db)
 

--- a/pangres/tests/test_upsert_async.py
+++ b/pangres/tests/test_upsert_async.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""
+Async variant of module test_upsert. See its docstring.
+"""
+import pandas as pd
+import pytest
+import random
+from sqlalchemy import VARCHAR
+from pangres import aupsert
+from pangres.examples import _TestsExampleTable
+from pangres.tests.conftest import ReaderSQLExampleTables, adrop_table_if_exists
+
+
+# # Config
+
+table_name = 'test_upsert'
+# there is a difference with the sync tests here: adding columns and changing their types
+# is not implemented yet
+default_args = {'table_name':table_name, 'create_schema':True}
+
+
+# # Test data
+
+# +
+df = _TestsExampleTable.create_example_df(nb_rows=5)
+# test for NULL values except for boolean column
+df.iloc[0,[ix for ix, col in enumerate(df.columns) if col != 'likes_pizza']] = None
+
+# test for update
+df2 = _TestsExampleTable.create_example_df(nb_rows=6)
+
+# test for ignore
+df3 = _TestsExampleTable.create_example_df(nb_rows=6)
+# -
+
+# # Tests
+# ORDER MATTERS!
+
+# ## Create table
+
+@pytest.mark.asyncio
+async def test_create_table(engine, schema):
+    # dtype for index for MySQL... (can't have flexible text length)
+    dtype = {'profileid':VARCHAR(10)} if 'mysql' in engine.dialect.dialect_description else None
+    
+    await adrop_table_if_exists(engine=engine, schema=schema, table_name=table_name)
+    await aupsert(engine=engine, schema=schema, df=df, if_row_exists='update', dtype=dtype, **default_args)
+    df_db = await ReaderSQLExampleTables.aread(engine=engine, schema=schema, table_name=table_name)
+    pd.testing.assert_frame_equal(df, df_db)
+
+# ## INSERT UPDATE 
+
+@pytest.mark.asyncio
+async def test_upsert_update(engine, schema):
+    dtype = {'profileid':VARCHAR(10)} if 'mysql' in engine.dialect.dialect_description else None
+
+    await aupsert(engine=engine, schema=schema, df=df2, if_row_exists='update', dtype=dtype, **default_args)
+    df_db = await ReaderSQLExampleTables.aread(engine=engine, schema=schema, table_name=table_name)
+    pd.testing.assert_frame_equal(df2, df_db)
+
+# ## INSERT IGNORE
+
+@pytest.mark.asyncio
+async def test_upsert_ignore(engine, schema):
+    dtype = {'profileid':VARCHAR(10)} if 'mysql' in engine.dialect.dialect_description else None
+
+    await adrop_table_if_exists(engine=engine, schema=schema, table_name=table_name)
+    for _df in (df, df3):
+        await aupsert(engine=engine, schema=schema, df=_df, if_row_exists='ignore', dtype=dtype, **default_args)
+    df_db = await ReaderSQLExampleTables.aread(engine=engine, schema=schema, table_name=table_name)
+    expected = pd.concat((df, df3.tail(1)), axis=0)
+    pd.testing.assert_frame_equal(expected, df_db)
+
+# # ~~Add colums with crappy names and~~ insert crappy text values
+#
+# There is a difference with the sync test here: we don't do test for adding columns as this is not supported yet.
+#
+# We will insert our bad texts inside of the column "email" instead of in a new column called "text".
+
+@pytest.mark.asyncio
+async def test_crappy_text_insert(engine, schema):
+    is_mysql = 'mysql' in engine.dialect.dialect_description
+    dtype = {'profileid':VARCHAR(10)} if is_mysql else None
+
+    # mix crappy letters with a few normal ones
+    crap_char_seq = """/_- ?§$&"',:;*()%[]{}|<>=!+#""" + "\\" + "sknalji"  
+
+    # add crappy text in the column 'email'
+    create_random_text = lambda: ''.join([random.choice(crap_char_seq) for i in range(10)])
+
+    df_test = (pd.DataFrame({'email': [create_random_text() for i in range(10)]})
+               .rename_axis(['profileid'], axis='index', inplace=False))
+    await aupsert(engine=engine, schema=schema, df=df_test, if_row_exists='update', dtype=dtype, **default_args)
+
+# # Another test with the column name `values` (see issue #34 of pangres)
+
+@pytest.mark.asyncio
+async def test_column_named_values(engine, schema):
+    df = pd.DataFrame({'values': range(5, 9)}, index=pd.Index(range(1, 5), name='idx'))
+    await aupsert(engine=engine, schema=schema, df=df, if_row_exists='update', table_name='test_column_values')

--- a/pangres/tests/test_upsert_speed.py
+++ b/pangres/tests/test_upsert_speed.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 # coding: utf-8
+"""
+Benchmarks of the following operations:
+1. CREATE TABLE... with pandas
+2. CREATE TABLE... with pangres (by default a table gets created
+when you use upsert if it did not already exist)
+3. INSERT... ON CONFLICT IGNORE with pangres
+4. INSERT... ON CONFLICT UPDATE with pangres
+"""
 import json
 from math import floor
 from sqlalchemy import VARCHAR

--- a/pangres/tests/test_upsert_speed_async.py
+++ b/pangres/tests/test_upsert_speed_async.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""
+Async variant of module test_upsert. See its docstring.
+
+Pandas does not support async so we won't do tests for creating tables.
+
+Also pytest-benchmark does not support async which is why we turn our
+coroutines `adrop_table_if_exists` and `aupsert` to sync (we have
+to for async engines because their already implemented sync variants
+would not work)
+"""
+import asyncio
+import json
+from math import floor
+from sqlalchemy import VARCHAR
+from pangres import aupsert
+from pangres.examples import _TestsExampleTable
+from pangres.tests.conftest import adrop_table_if_exists
+
+
+# # Test data
+
+
+# +
+df = _TestsExampleTable.create_example_df(nb_rows=20000)
+
+# pandas can't handle JSON
+# so for testing the speed of pd.to_sql we need to cast list and dicts to str
+json_like_to_str = lambda x: json.dumps(x) if isinstance(x, (dict, list)) else x
+df_no_json_like = df.assign(favorite_colors=lambda df: df['favorite_colors'].map(json_like_to_str))
+
+
+# -
+
+
+# # Helpers
+
+# +
+# table for speed test with pangres
+pangres_table_name = 'test_speed_pangres'
+
+async def acreate_or_update(engine, schema, if_row_exists):
+    # MySQL does not want flexible text length in indices/PK
+    dtype={'profileid':VARCHAR(10)} if 'mysql' in engine.dialect.dialect_description else None
+    await aupsert(engine=engine, df=df, schema=schema,
+                  table_name=pangres_table_name, if_row_exists=if_row_exists,
+                  dtype=dtype)
+
+# we need those two functions for async engines
+def create_or_update_sync(engine, schema, if_row_exists):
+    loop = asyncio.get_event_loop()
+    coroutines = [acreate_or_update(engine=engine, schema=schema, if_row_exists=if_row_exists)]
+    tasks = asyncio.gather(*coroutines, return_exceptions=True)
+    results = loop.run_until_complete(tasks)
+    for r in results:
+        if isinstance(r, Exception):
+            raise r
+
+def drop_table_if_exists_sync(engine, schema, table_name):
+    loop = asyncio.get_event_loop()
+    coroutines = [adrop_table_if_exists(engine=engine, schema=schema, table_name=table_name)]
+    tasks = asyncio.gather(*coroutines, return_exceptions=True)
+    results = loop.run_until_complete(tasks)
+    for r in results:
+        if isinstance(r, Exception):
+            raise r
+# -
+
+# # Creation speed
+
+
+# do all tests only once because:
+#
+# 1. we have enough data as is
+# 2. we would have to drop and recreate table at each loop...
+
+def test_creation_speed_with_upsert(engine, schema, benchmark):
+    # benchmark is implicitly imported with pytest
+    drop_table_if_exists_sync(engine=engine, schema=schema, table_name=pangres_table_name)
+    f = lambda: create_or_update_sync(engine=engine, schema=schema, if_row_exists='update')
+    benchmark.pedantic(f, rounds=1, iterations=1)
+
+
+# # Upsert overwrite speed
+
+def test_upsert_overwrite_speed_with_upsert(engine, schema, benchmark):
+    f = lambda: create_or_update_sync(engine=engine, schema=schema, if_row_exists='update')
+    benchmark.pedantic(f, rounds=1, iterations=1)
+
+
+# # Upsert keep speed
+
+def test_upsert_keep_speed_with_upsert(engine, schema, benchmark):
+    f = lambda: create_or_update_sync(engine=engine, schema=schema, if_row_exists='ignore')
+    benchmark.pedantic(f, rounds=1, iterations=1)

--- a/pangres/tests/test_yield_chunks.py
+++ b/pangres/tests/test_yield_chunks.py
@@ -10,7 +10,7 @@ import pandas as pd
 from sqlalchemy import VARCHAR
 from pangres import upsert
 from pangres.examples import _TestsExampleTable
-from pangres.tests.conftest import read_example_table_from_db, drop_table_if_exists
+from pangres.tests.conftest import ReaderSQLExampleTables, drop_table_if_exists
 
 
 # # Insert values one by one
@@ -36,5 +36,5 @@ def test_get_nb_rows(engine, schema):
 
     # verify the inserted data is as expected
     # we sort the index for MySQL
-    df_db = read_example_table_from_db(engine=engine, schema=schema, table_name=table_name)
+    df_db = ReaderSQLExampleTables.read(engine=engine, schema=schema, table_name=table_name)
     pd.testing.assert_frame_equal(df.sort_index(), df_db.sort_index())

--- a/pangres/upsert.py
+++ b/pangres/upsert.py
@@ -161,3 +161,10 @@ class UpsertQuery:
             if hasattr(connection, 'commit'):
                 connection.commit()
         return result
+
+    async def aexecute(self, db_type, values, if_row_exists):
+        query = self.create_query(db_type=db_type, values=values, if_row_exists=if_row_exists)
+        async with self.engine.connect() as connection:
+            result = await connection.execute(query)
+            await connection.commit()
+        return result


### PR DESCRIPTION
I have good hopes I can make this work :sunglasses:. But I am not a super expert on async so if anyone wants to check out what I am doing you are very welcome to :see_no_evil: !

- [x] make a working function `aupsert`
- [x] modify `conftest.py` so we can generate tests for async engines in there too. Of course we should not generate sync tests for async engines. I will probably use a label for the module to differentiate sync and async tests (with pytest it is possible to access the module names when generating tests)
- [x] add extra tests for async (will probably involve a lot of copy pasting, not great but at least it's easy and reliable...)
- [ ] review (own review + someone else's if possible)