### PR TITLE
Add Literal type hinting for `if_row_exists` arg

### DIFF
--- a/pangres/core.py
+++ b/pangres/core.py
@@ -7,7 +7,7 @@ that will be directly exposed to its users.
 """
 import pandas as pd
 from sqlalchemy.engine import Connectable
-from typing import Union
+from typing import Literal, Union
 
 # local imports
 from pangres.executor import Executor
@@ -22,7 +22,7 @@ from pangres.pangres_types import AsyncConnectable, AUpsertResult, UpsertResult
 def upsert(con: Connectable,
            df: pd.DataFrame,
            table_name: str,
-           if_row_exists: str,
+           if_row_exists: Literal['ignore', 'update'],
            schema: Union[str, None] = None,
            create_schema: bool = False,
            create_table: bool = True,
@@ -310,7 +310,7 @@ def upsert(con: Connectable,
 async def aupsert(con: AsyncConnectable,
                   df: pd.DataFrame,
                   table_name: str,
-                  if_row_exists: str,
+                  if_row_exists: Literal['ignore', 'update'],
                   schema: Union[str, None] = None,
                   create_schema: bool = False,
                   create_table: bool = True,

--- a/pangres/engine.py
+++ b/pangres/engine.py
@@ -14,7 +14,7 @@ from sqlalchemy.sql import null
 from sqlalchemy.schema import PrimaryKeyConstraint, CreateSchema, Table
 from alembic.runtime.migration import MigrationContext
 from alembic.operations import Operations
-from typing import Any, List, Union
+from typing import Any, List, Union, Literal
 # local imports
 from pangres.helpers import _sqla_gt14, _sqla_gt20
 from pangres.logger import log
@@ -518,7 +518,7 @@ class PandasSpecialEngine:
                     values[i][j] = str(val)
         return values
 
-    def upsert(self, if_row_exists: str, chunksize: int = 10000) -> None:
+    def upsert(self, if_row_exists: Literal['ignore', 'update'], chunksize: int = 10000) -> None:
         """
         Generates and executes an upsert (insert update or
         insert ignore depending on :if_row_exists:) statement
@@ -550,7 +550,7 @@ class PandasSpecialEngine:
         for chunk in chunks:
             upq.execute(db_type=self._db_type, values=chunk, if_row_exists=if_row_exists)
 
-    def upsert_yield(self, if_row_exists: str, chunksize: int = 10000):
+    def upsert_yield(self, if_row_exists: Literal['ignore', 'update'], chunksize: int = 10000):
         """
         Same as method `upsert` but gives back an sqlalchemy object
         (sqlalchemy.engine.cursor.LegacyCursorResult) for each chunk inserted
@@ -615,7 +615,7 @@ class PandasSpecialEngine:
                                                                            db_table=db_table)
         await self.connection.run_sync(ddl_func)
 
-    async def aupsert(self, if_row_exists: str, chunksize: int = 10000):
+    async def aupsert(self, if_row_exists: Literal['ignore', 'update'], chunksize: int = 10000):
         assert if_row_exists in ('ignore', 'update')
         values = self._get_values_to_insert()
         chunks = self._create_chunks(values=values, chunksize=chunksize)
@@ -623,7 +623,7 @@ class PandasSpecialEngine:
         for chunk in chunks:
             await upq.aexecute(db_type=self._db_type, values=chunk, if_row_exists=if_row_exists)
 
-    async def aupsert_yield(self, if_row_exists: str, chunksize: int = 10000):
+    async def aupsert_yield(self, if_row_exists: Literal['ignore', 'update'], chunksize: int = 10000):
         assert if_row_exists in ('ignore', 'update')
         values = self._get_values_to_insert()
         chunks = self._create_chunks(values=values, chunksize=chunksize)

--- a/pangres/executor.py
+++ b/pangres/executor.py
@@ -4,7 +4,7 @@ Read docstring of main class Executor
 """
 import pandas as pd
 from sqlalchemy.engine import Connectable
-from typing import Union
+from typing import Union, Literal
 
 # local imports
 from pangres.engine import PandasSpecialEngine
@@ -70,7 +70,7 @@ class Executor:
         if self.add_new_columns and pse.table_exists():
             pse.add_new_columns()
 
-    def execute(self, connectable: Connectable, if_row_exists: str, chunksize: int) -> None:
+    def execute(self, connectable: Connectable, if_row_exists: Literal['ignore', 'update'], chunksize: int) -> None:
         """
         Handles the actual upsert operation.
         """
@@ -86,7 +86,7 @@ class Executor:
                 return
             pse.upsert(if_row_exists=if_row_exists, chunksize=chunksize)
 
-    def execute_yield(self, connectable: Connectable, if_row_exists: str, chunksize: int):
+    def execute_yield(self, connectable: Connectable, if_row_exists: Literal['ignore', 'update'], chunksize: int):
         """
         Same as `execute` but for each chunk upserted yields a
         `sqlalchemy.engine.cursor.LegacyCursorResult` object with which
@@ -130,7 +130,7 @@ class Executor:
             if table_exists:
                 await pse.aadd_new_columns()
 
-    async def aexecute(self, async_connectable, if_row_exists: str, chunksize: int) -> None:
+    async def aexecute(self, async_connectable, if_row_exists: Literal['ignore', 'update'], chunksize: int) -> None:
         async with TransactionHandler(connectable=async_connectable) as trans:
             # setup
             pse = PandasSpecialEngine(connection=trans.connection,  # type: ignore
@@ -145,7 +145,7 @@ class Executor:
                 return
             await pse.aupsert(if_row_exists=if_row_exists, chunksize=chunksize)
 
-    async def aexecute_yield(self, async_connectable, if_row_exists: str, chunksize: int):
+    async def aexecute_yield(self, async_connectable, if_row_exists: Literal['ignore', 'update'], chunksize: int):
         async with TransactionHandler(connectable=async_connectable) as trans:
             # setup
             pse = PandasSpecialEngine(connection=trans.connection,  # type: ignore


### PR DESCRIPTION
This change improves the type hinting within the library, and also in external uses.

Main change:
* Find: `if_row_exists: str`
* Replace with: `if_row_exists: Literal['ignore', 'update']`

Also added the appropriate `from typing import ..., Literal`

Main benefit: This change allows users to Ctrl+Space in their IDE to see options for that arg.